### PR TITLE
refactor snake component: use the snake tail movement

### DIFF
--- a/src/snake/components.rs
+++ b/src/snake/components.rs
@@ -1,6 +1,6 @@
 use std::collections::LinkedList;
 
-use bevy::prelude::Component;
+use bevy::prelude::{Component, Entity};
 
 #[derive(Eq, PartialEq, Clone, Copy)]
 pub enum Direction {
@@ -12,9 +12,10 @@ pub enum Direction {
 }
 
 #[derive(Component)]
-pub struct SnakePiece(pub Direction);
+pub struct SnakePiece;
 
 #[derive(Component)]
 pub struct Snake {
-    pub body: LinkedList<SnakePiece>,
+    pub body: LinkedList<Entity>,
+    pub direction: Direction,
 }

--- a/src/snake/systems.rs
+++ b/src/snake/systems.rs
@@ -18,76 +18,86 @@ pub fn spawn_snake(
     resource_query: Res<SnakeResources>,
 ) {
     let window: &Window = window_query.get_single().unwrap();
-    let mut snake = LinkedList::new();
-    snake.push_back(SnakePiece(Direction::None));
-    commands.spawn((
-        SpriteBundle {
-            transform: Transform::from_xyz(window.width() / 2.0, window.height() / 2.0, 0.0),
-            texture: resource_query.image.clone(),
-            ..default()
-        },
-        Snake { body: snake },
-    ));
+    let mut snake_body = LinkedList::new();
+    let piece = commands
+        .spawn((
+            SpriteBundle {
+                transform: Transform::from_xyz(window.width() / 2.0, window.height() / 2.0, 0.0),
+                texture: resource_query.image.clone(),
+                ..default()
+            },
+            SnakePiece,
+        ))
+        .id();
+    snake_body.push_back(piece);
+    commands.spawn(Snake {
+        body: snake_body,
+        direction: Direction::None,
+    });
 }
 
 pub fn snake_direction(keyboard_input: Res<Input<KeyCode>>, mut snake_query: Query<&mut Snake>) {
-    let mut direction = Direction::None;
-    if keyboard_input.pressed(KeyCode::Left) || keyboard_input.pressed(KeyCode::A) {
-        direction = Direction::Left;
-    }
-    if keyboard_input.pressed(KeyCode::Right) || keyboard_input.pressed(KeyCode::D) {
-        direction = Direction::Right;
-    }
-    if keyboard_input.pressed(KeyCode::Up) || keyboard_input.pressed(KeyCode::W) {
-        direction = Direction::Up;
-    }
-    if keyboard_input.pressed(KeyCode::Down) || keyboard_input.pressed(KeyCode::S) {
-        direction = Direction::Down;
-    }
-    if direction == Direction::None {
-        return;
-    }
-
-    // TODO: better update method?
-    // E.g. remove the snake tail, add a piece to the head. That seems that snake moved!
     if let Ok(mut snake) = snake_query.get_single_mut() {
-        let mut iter = snake.body.iter_mut();
-        let mut prev = Direction::None;
-        // the movement of every snake piece follows the previous one,
-        // and the head of snake follows its or the keyboard input.
-        loop {
-            match iter.next() {
-                Some(piece) => {
-                    let tmp = piece.0;
-                    piece.0 = prev;
-                    prev = tmp;
-                }
-                None => break,
-            }
+        if keyboard_input.pressed(KeyCode::Left) || keyboard_input.pressed(KeyCode::A) {
+            snake.direction = Direction::Left;
         }
-        if let Some(head) = snake.body.front_mut() {
-            head.0 = direction;
+        if keyboard_input.pressed(KeyCode::Right) || keyboard_input.pressed(KeyCode::D) {
+            snake.direction = Direction::Right;
+        }
+        if keyboard_input.pressed(KeyCode::Up) || keyboard_input.pressed(KeyCode::W) {
+            snake.direction = Direction::Up;
+        }
+        if keyboard_input.pressed(KeyCode::Down) || keyboard_input.pressed(KeyCode::S) {
+            snake.direction = Direction::Down;
         }
     }
 }
 
 pub fn snake_movement(
-    snake_query: Query<&Snake>,
-    mut snake_transform_query: Query<&mut Transform, With<Snake>>,
+    mut snake_query: Query<&mut Snake>,
+    mut snake_transform_query: Query<(Entity, &mut Transform), With<SnakePiece>>,
     time: Res<Time>,
 ) {
-    if let Ok(snake) = snake_query.get_single() {
-        for piece in snake.body.iter() {
-            if piece.0 == Direction::None {
-                continue;
-            }
-            if let Ok(mut transform) = snake_transform_query.get_single_mut() {
-                transform.translation += match piece.0 {
-                    Direction::Left => Vec3::new(-SNAKE_SPEED * time.delta_seconds(), 0.0, 0.0),
-                    Direction::Right => Vec3::new(SNAKE_SPEED * time.delta_seconds(), 0.0, 0.0),
-                    Direction::Up => Vec3::new(0.0, SNAKE_SPEED * time.delta_seconds(), 0.0),
-                    Direction::Down => Vec3::new(0.0, -SNAKE_SPEED * time.delta_seconds(), 0.0),
-                    _ => Vec3::ZERO,
+    if let Ok(mut snake) = snake_query.get_single_mut() {
+        if let Some(tail) = snake.body.pop_back() {
+            let head = match snake.body.front() {
+                Some(piece) => *piece,
+                None => tail,
+            };
+            snake.body.push_front(tail);
+            // if there is only one snake piece
+            if head == tail {
+                if let Ok((_, mut transform)) = snake_transform_query.get_single_mut() {
+                    transform.translation += match snake.direction {
+                        Direction::Left => Vec3::new(-SNAKE_SPEED * time.delta_seconds(), 0.0, 0.0),
+                        Direction::Right => Vec3::new(SNAKE_SPEED * time.delta_seconds(), 0.0, 0.0),
+                        Direction::Up => Vec3::new(0.0, SNAKE_SPEED * time.delta_seconds(), 0.0),
+                        Direction::Down => Vec3::new(0.0, -SNAKE_SPEED * time.delta_seconds(), 0.0),
+                        _ => Vec3::ZERO,
+                    }
+                }
+            } else {
+                let mut head_translation = Vec3::new(0.0, 0.0, 0.0);
+                if let Ok((_, head_transform)) = snake_transform_query.get(head) {
+                    head_translation = head_transform.translation;
+                }
+                if let Ok((_, mut tail_transform)) = snake_transform_query.get_mut(tail) {
+                    tail_transform.translation = head_translation
+                        + match snake.direction {
+                            Direction::Left => {
+                                Vec3::new(-SNAKE_SPEED * time.delta_seconds(), 0.0, 0.0)
+                            }
+                            Direction::Right => {
+                                Vec3::new(SNAKE_SPEED * time.delta_seconds(), 0.0, 0.0)
+                            }
+                            Direction::Up => {
+                                Vec3::new(0.0, SNAKE_SPEED * time.delta_seconds(), 0.0)
+                            }
+                            Direction::Down => {
+                                Vec3::new(0.0, -SNAKE_SPEED * time.delta_seconds(), 0.0)
+                            }
+                            _ => Vec3::ZERO,
+                        };
                 }
             }
         }
@@ -96,45 +106,66 @@ pub fn snake_movement(
 
 pub fn snake_dead_check(
     mut commands: Commands,
-    snake_query: Query<(Entity, &Transform), With<Snake>>,
+    mut snake_query: Query<&mut Snake>,
+    snake_transform_query: Query<(Entity, &Transform), With<SnakePiece>>,
     window_query: Query<&Window, With<PrimaryWindow>>,
 ) {
-    if let Ok((snake_entity, snake_transform)) = snake_query.get_single() {
-        let window = window_query.get_single().unwrap();
-        let x_min = SNAKE_SIZE / 2.0;
-        let x_max = window.width() - x_min;
-        let y_min = SNAKE_SIZE / 2.0;
-        let y_max = window.height() - y_min;
+    // snake will never be destroyed
+    let mut snake = snake_query.get_single_mut().unwrap();
 
-        let translation = snake_transform.translation;
-        if translation.x < x_min
-            || translation.x > x_max
-            || translation.y < y_min
-            || translation.y > y_max
-        {
-            println!("snake dead");
-            commands.entity(snake_entity).despawn();
+    let snake_head_entity = match snake.body.front() {
+        Some(entity) => entity,
+        None => return,
+    };
+    let (_, snake_head_transform) = snake_transform_query.get(*snake_head_entity).unwrap();
+
+    let window = window_query.get_single().unwrap();
+    let x_min = SNAKE_SIZE / 2.0;
+    let x_max = window.width() - x_min;
+    let y_min = SNAKE_SIZE / 2.0;
+    let y_max = window.height() - y_min;
+
+    let translation = snake_head_transform.translation;
+    if translation.x < x_min
+        || translation.x > x_max
+        || translation.y < y_min
+        || translation.y > y_max
+    {
+        println!("snake dead");
+        // clean snake piece entity list
+        snake.body.clear();
+        // destroy snake pieces
+        for iter in snake_transform_query.iter() {
+            commands.entity(iter.0).despawn();
         }
     }
 }
 
 pub fn snake_eat_bean_check(
     mut commands: Commands,
-    snake_query: Query<&Transform, With<Snake>>,
+    snake_query: Query<&Snake>,
+    snake_transform_query: Query<(Entity, &Transform), With<SnakePiece>>,
     bean_query: Query<(Entity, &Transform), With<Bean>>,
 ) {
-    if let Ok(snake_transform) = snake_query.get_single() {
-        if let Ok((bean_entity, bean_transform)) = bean_query.get_single() {
-            let distance = snake_transform
-                .translation
-                .distance(bean_transform.translation);
-            let snake_radius = SNAKE_SIZE / 2.0;
-            // TODO: use unique size
-            let bean_radius = SNAKE_SIZE / 2.0;
-            if distance < snake_radius + bean_radius {
-                println!("snake eat bean!");
-                commands.entity(bean_entity).despawn();
-            }
+    // snake will never be destroyed
+    let snake = snake_query.get_single().unwrap();
+
+    let snake_head_entity = match snake.body.front() {
+        Some(entity) => entity,
+        None => return,
+    };
+    let (_, snake_head_transform) = snake_transform_query.get(*snake_head_entity).unwrap();
+
+    if let Ok((bean_entity, bean_transform)) = bean_query.get_single() {
+        let distance = snake_head_transform
+            .translation
+            .distance(bean_transform.translation);
+        let snake_radius = SNAKE_SIZE / 2.0;
+        // TODO: use unique size
+        let bean_radius = SNAKE_SIZE / 2.0;
+        if distance < snake_radius + bean_radius {
+            println!("snake eat bean!");
+            commands.entity(bean_entity).despawn();
         }
     }
 }


### PR DESCRIPTION
use LinkedList to refactor snake component:

```rust
#[derive(Component)]
pub struct SnakePiece;

#[derive(Component)]
pub struct Snake {
    pub body: LinkedList<Entity>,
    pub direction: Direction,
}
```